### PR TITLE
Support for Linux Platform

### DIFF
--- a/Sources/Link.swift
+++ b/Sources/Link.swift
@@ -62,10 +62,10 @@ public struct Link {
   public var templated: Bool {
     struct Templated {
       // swiftlint:disable:next force_try
-      static let expression = try! NSRegularExpression(pattern: "\\{.+\\}")
+      static let expression = try! NSRegularExpression(pattern: "\\{.+\\}", options: [])
     }
     let range = NSRange(location: 0, length: href.characters.count)
-    return Templated.expression.numberOfMatches(in: href, range: range) > 0
+    return Templated.expression.numberOfMatches(in: href, options: [], range: range) > 0
   }
 
   // Optional attributes


### PR DESCRIPTION
Hi, I'm just using this for parsing hal+json content in my [own library](https://github.com/noppoMan/aws-sdk-swift) and then, I saw following 2 compiling errors on `Swift version 3.1 (swift-3.1-RELEASE) Target: x86_64-unknown-linux-gnu` environment.

```swift
error: incorrect argument label in call (have 'pattern:', expected 'coder:')
      static let expression = try! NSRegularExpression(pattern: "\\{.+\\}")
                                                      ^~~~~~~~
                                                       coder
```

```swift
error: missing argument for parameter 'options' in call
    return Templated.expression.numberOfMatches(in: href, range: range) > 0
                                                        ^
                                                        , options: <#NSMatchingOptions#>
Foundation.NSRegularExpression:4:17: note: 'numberOfMatches(in:options:range:)' declared here
    public func numberOfMatches(in string: String, options: Foundation.NSMatchingOptions, range: Foundation.NSRange) -> Int
```

The Linux version of NSRegularExpression and numberOfMatches seems to be unable to omit options label. 

So I tried to add options labels and it worked fine on Linux. [Here is testing results](https://travis-ci.org/noppoMan/aws-sdk-swift) 
If you'd like it, please merge this. Anyways, Thanks for creating such a great library.